### PR TITLE
Modified editWorkout and editExerciseMutations

### DIFF
--- a/resolvers/exercise/exerciseMutations.js
+++ b/resolvers/exercise/exerciseMutations.js
@@ -35,6 +35,26 @@ const editExercise = async (root, args, context, info) => {
 		data: { ...properties },
 		where: { id: args.exerciseId }
 	});
+	//If the user passes completed boolean, check if the workout is also completed or not to update it's status.
+	if (args.completed !== null || args.completed !== undefined) {
+		const exercisesWorkout = await context.prisma
+			.exercise({ id: args.exerciseId })
+			.workout();
+		const incompleteWorkoutExercises = await context.prisma
+			.workout({ id: exercisesWorkout.id })
+			.exercises({ where: { completed: false } });
+		if (incompleteWorkoutExercises.length === 0) {
+			const updateWorkout = await context.prisma.updateWorkout({
+				where: { id: exercisesWorkout.id },
+				data: { completed: true }
+			});
+		} else {
+			const updateWorkout = await context.prisma.updateWorkout({
+				where: { id: exercisesWorkout.id },
+				data: { completed: false }
+			});
+		}
+	}
 	return updatedExercise;
 };
 

--- a/resolvers/workout/workoutMutations.js
+++ b/resolvers/workout/workoutMutations.js
@@ -64,7 +64,24 @@ const editWorkout = async (root, args, context, info) => {
 		data: { ...properties },
 		where: { id: args.id }
 	});
-	return updatedWorkout;
+	//If a user marks a workout as complete or not, update the exercises inside of it to match it as well.
+	if (args.completed !== null || args.completed !== undefined) {
+		const updatedWorkoutExercises = await context.prisma
+			.workout({ id: args.id })
+			.exercises();
+		//If updatedWorkout is completed, make sure every exercise inside of it is completed.
+		for (let i = 0; i < updatedWorkoutExercises.length; i++) {
+			let foundExercise = updatedWorkoutExercises[i];
+			if (foundExercise.completed !== args.completed) {
+				const updatedExercise = await context.prisma.updateExercise({
+					data: { completed: args.completed },
+					where: { id: foundExercise.id }
+				});
+			}
+		}
+	}
+	//Return the workout with the exercises in it that are now updated.
+	return context.prisma.workout({ id: args.id });
 };
 
 module.exports = {


### PR DESCRIPTION
When editWorkout and editExercise mutations are passed completed arguments, they update the parent/child records to match their status.

editWorkout makes all of the exercises completed under it if it is marked complete. Will also mark them incomplete if it is marked not completed, because if the workout isn't complete, then not all of the exercises will be either.

editExercise will check if all exercises of the same workout are complete, if so, it will make the workout completed as well.